### PR TITLE
Get javadocs to skip checks for sonatype

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,6 +149,22 @@
                     <target>11</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.2.0</version>
+                <configuration>
+                  <source>8</source>
+                  <doclint>none</doclint>
+                </configuration>
+                <executions>
+                  <execution>
+                    <id>attach-javadocs</id>
+                    <goals>
+                      <goal>jar</goal>
+                    </goals>
+                  </execution>
+                </executions>
+              </plugin>
 
         </plugins>
     </build>


### PR DESCRIPTION
Get javadocs to skip checks while still creating jar for sonatype